### PR TITLE
fix: supervise worker tasks, scope pod query to node, repair healthcheck

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -24,6 +24,7 @@ FROM ubuntu:22.04
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     libssl3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r oomwatcher \

--- a/oom-watcher/src/kubernetes.rs
+++ b/oom-watcher/src/kubernetes.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use anyhow::{anyhow, Result};
 use k8s_openapi::api::core::v1::Pod;
-use kube::{Api, Client, Config};
+use kube::{api::ListParams, Api, Client, Config};
 use log::{debug, warn};
 use regex::Regex;
 
@@ -86,17 +86,13 @@ impl KubernetesClient {
         &self,
         container_id: &str,
     ) -> Result<Option<(String, String, String)>> {
-        let pods = self.pods_api.list(&Default::default()).await?;
+        // Scope the query to this node so we don't list every pod in the
+        // cluster on each OOM event; the kubelet supports the spec.nodeName
+        // field selector for pods.
+        let params = ListParams::default().fields(&format!("spec.nodeName={}", self.node_name));
+        let pods = self.pods_api.list(&params).await?;
 
         for pod in pods.items {
-            if let Some(pod_spec) = &pod.spec {
-                if let Some(node_name) = &pod_spec.node_name {
-                    if node_name != &self.node_name {
-                        continue;
-                    }
-                }
-            }
-
             if let Some(status) = &pod.status {
                 if let Some(container_statuses) = &status.container_statuses {
                     for container_status in container_statuses {

--- a/oom-watcher/src/main.rs
+++ b/oom-watcher/src/main.rs
@@ -50,14 +50,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app = metrics_collector.clone().create_server(metrics_port);
 
-    let metrics_server = task::spawn(async move {
-        info!(
-            "Starting Prometheus metrics server on port {}",
-            metrics_port
-        );
-        let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", metrics_port))
-            .await
-            .unwrap();
+    // Bind before spawning so a bind failure fails startup loudly, instead of
+    // panicking inside a detached task and leaving the process running blind.
+    info!(
+        "Starting Prometheus metrics server on port {}",
+        metrics_port
+    );
+    let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", metrics_port)).await?;
+
+    let mut metrics_server = task::spawn(async move {
         if let Err(e) = serve(listener, app).await {
             error!("Metrics server error: {}", e);
         }
@@ -132,15 +133,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("⏹️  Press Ctrl-C to stop monitoring");
 
     // Main event processing loop
-    let event_processor = task::spawn(async move {
+    let mut event_processor = task::spawn(async move {
         #[cfg(feature = "ebpf")]
         {
-            let mut ring_buf = RingBuf::try_from(
-                bpf.map_mut("EVENTS")
-                    .ok_or("Could not find map 'EVENTS'")
-                    .unwrap(),
-            )
-            .unwrap();
+            let events_map = match bpf.map_mut("EVENTS") {
+                Some(map) => map,
+                None => {
+                    error!("Could not find eBPF map 'EVENTS'; event processor stopping");
+                    return;
+                }
+            };
+            let mut ring_buf = match RingBuf::try_from(events_map) {
+                Ok(ring_buf) => ring_buf,
+                Err(e) => {
+                    error!("Failed to open 'EVENTS' ring buffer: {}", e);
+                    return;
+                }
+            };
             loop {
                 while let Some(item) = ring_buf.next() {
                     let data: &[u8] = &item;
@@ -261,12 +270,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // Wait for Ctrl-C
-    signal::ctrl_c().await?;
-    info!("Shutting down OOM Watcher...");
+    // Run until shutdown is requested or a worker task exits unexpectedly. If a
+    // worker dies, return an error so the process exits non-zero and the
+    // DaemonSet restarts the pod, rather than staying up but no longer watching.
+    let outcome: Result<(), Box<dyn std::error::Error>> = tokio::select! {
+        res = signal::ctrl_c() => {
+            res?;
+            info!("Shutting down OOM Watcher...");
+            Ok(())
+        }
+        res = &mut event_processor => {
+            error!("Event processor task exited unexpectedly: {:?}", res);
+            Err("event processor task exited".into())
+        }
+        res = &mut metrics_server => {
+            error!("Metrics server task exited unexpectedly: {:?}", res);
+            Err("metrics server task exited".into())
+        }
+    };
 
     event_processor.abort();
     metrics_server.abort();
 
-    Ok(())
+    outcome
 }


### PR DESCRIPTION
Three independent runtime fixes found while analysing the codebase. None overlap with #2.

### core — task supervision (reliability)
The metrics server and event-processor run as detached `task::spawn`s while `main` blocked on `ctrl_c()`. A panic in either (metrics port already bound; `EVENTS` map missing) only killed that task — the process stayed up reporting healthy while doing nothing.

- Bind the metrics `TcpListener` **before** spawning, propagating bind errors so startup fails loudly.
- Replace the `.unwrap().unwrap()` on the `EVENTS` map with explicit error handling.
- Supervise both tasks with `tokio::select!`; if a worker exits unexpectedly, return an error so the process exits non-zero and the DaemonSet restarts the pod.

### k8s — scope pod lookup to the node (scalability)
`get_pod_info_from_container_id` listed **every pod in the cluster** on each OOM event, then filtered client-side. Now uses a `spec.nodeName` field selector so the kubelet returns only this node's pods; the redundant client-side node filter is removed.

### docker — repair HEALTHCHECK
The runtime image's `HEALTHCHECK` calls `curl`, which was never installed. Added `curl` to the runtime stage.