### PR TITLE
fix: patch dependency advisories and add supply-chain CI gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+    groups:
+      aya:
+        patterns:
+          - "aya*"
+
+  - package-ecosystem: docker
+    directories:
+      - "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@stable
@@ -56,7 +56,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@stable
@@ -99,7 +99,7 @@ jobs:
       matrix:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@stable
@@ -130,6 +130,26 @@ jobs:
         run: cross +nightly build --target ${{ matrix.target }} --release --no-default-features
         env:
           CARGO_TARGET_BPFEL_UNKNOWN_NONE_LINKER: bpf-linker
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo audit
+        # rustls-webpki advisories arrive transitively via kube 0.87 (rustls 0.21);
+        # resolving them needs a kube major bump, which dependabot will surface.
+        run: >
+          cargo audit
+          --ignore RUSTSEC-2026-0104
+          --ignore RUSTSEC-2026-0098
+          --ignore RUSTSEC-2026-0099
 
   semantic-pr:
     name: Semantic PR Title

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       should-release: ${{ steps.set-outputs.outputs.should-release }}
       new-version: ${{ steps.set-outputs.outputs.new-version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
@@ -98,7 +98,7 @@ jobs:
     needs: [detect-changes, build-and-push]
     if: needs.detect-changes.outputs.should-release == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.0
@@ -132,7 +132,7 @@ jobs:
     needs: [detect-changes, build-and-push, helm-package]
     if: needs.detect-changes.outputs.should-release == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -1395,15 +1395,8 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/oom-watcher/Cargo.toml
+++ b/oom-watcher/Cargo.toml
@@ -10,7 +10,7 @@ default = ["ebpf"]
 ebpf = []
 
 [dependencies]
-bytes = "1"
+bytes = "1.11"
 oom-watcher-common = { path = "../oom-watcher-common", features = ["user"] }
 
 anyhow = { workspace = true, default-features = true }
@@ -31,7 +31,9 @@ tokio = { workspace = true, features = [
 # Kubernetes and Prometheus dependencies
 kube = { version = "0.87", features = ["client", "config", "derive"] }
 k8s-openapi = { version = "0.20", features = ["v1_28"] }
-prometheus = "0.13"
+# default-features disabled to drop the unmaintained protobuf 2.x encoder
+# (RUSTSEC-2024-0437); only the text exposition format (TextEncoder) is used.
+prometheus = { version = "0.13", default-features = false }
 axum = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.0"


### PR DESCRIPTION
Supply-chain hardening for ebpf-oom-watcher.

### Dependency advisories fixed
- **`bytes` 1.10 → 1.11** — RUSTSEC-2026-0007 (integer overflow in `BytesMut::reserve`).
- **dropped `protobuf` 2.x** — RUSTSEC-2024-0437 (uncontrolled-recursion crash). It was pulled only by `prometheus`'s default `protobuf` feature; we use `TextEncoder` only, so `default-features = false` removes it entirely.

### New CI gate
- **`cargo audit`** job in PR checks (prebuilt via `taiki-e/install-action`). The three `rustls-webpki` advisories come transitively through `kube 0.87` (rustls 0.21) and require a `kube` major bump — explicitly `--ignore`d with a comment so the gate is honest while dependabot drives the upgrade.

### Dependabot
- `cargo` (aya crates grouped), `docker` (both Dockerfiles), and `github-actions`, all weekly.

### Action version drift
- `actions/checkout` v5 → v6 across both workflows (org house standard).

Verified locally: `cargo audit` exits 0 with the three ignores; `protobuf` no longer in `Cargo.lock`.