### PR TITLE
refactor(k8s): extract OOM event enrichment into a pure, tested module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# Domain Context — ebpf-oom-watcher
+
+Domain vocabulary for the OOM watcher. Architecture reviews and grilling sessions
+use these terms exactly.
+
+## Terms
+
+- **OOM kill event** (`OomKillEvent`) — the raw record the kernel emits when it kills
+  a process for memory pressure. Captured by the eBPF probe at the `oom:mark_victim`
+  tracepoint and shipped to userspace over the ring buffer. Pure numbers + the process
+  `comm`; no Kubernetes context.
+
+- **Container identity** (`ContainerIdentity`) — the Kubernetes coordinates of the
+  container a killed process belonged to: `namespace`, `pod_name`, `container_name`,
+  `container_id`. Resolved from a PID by reading `/proc/<pid>/cgroup` for the container
+  id, then matching it against the pods scheduled on this node.
+
+- **Enrichment** — the step that takes a raw **OOM kill event** and a (possibly absent)
+  **container identity** and produces an **enriched OOM event**. The single rule it
+  encodes: `node_name` is known *iff* this process has a Kubernetes client (i.e. we are
+  running in-cluster), regardless of whether the container identity could be resolved.
+  Lives in `oom-watcher/src/enrich.rs` as the sole construction site for an enriched
+  event.
+
+- **Enriched OOM event** (`EnrichedOomEvent`) — an OOM kill event plus its node name,
+  optional container identity fields, and a wall-clock timestamp. The unit recorded as
+  Prometheus metrics and logged.
+
+- **Resolution** — the I/O act of turning a PID into a **container identity**. Three
+  outcomes: found (`Ok(Some)`), not found (`Ok(None)`), or lookup error (`Err`). The
+  watch loop logs the two failure outcomes distinctly, then collapses both to "no
+  identity" before handing off to **enrichment**.

--- a/oom-watcher-common/src/lib.rs
+++ b/oom-watcher-common/src/lib.rs
@@ -21,6 +21,19 @@ pub struct OomKillEvent {
     pub oom_score_adj: i16, // OOM score adjustment
 }
 
+/// Kubernetes coordinates of the container a killed process belonged to.
+///
+/// Resolved from a PID by reading `/proc/<pid>/cgroup` for the container id, then
+/// matching that id against the pods scheduled on this node.
+#[cfg(feature = "user")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContainerIdentity {
+    pub namespace: String,
+    pub pod_name: String,
+    pub container_name: String,
+    pub container_id: String,
+}
+
 #[cfg(feature = "user")]
 #[derive(Clone, Debug)]
 pub struct EnrichedOomEvent {

--- a/oom-watcher/src/enrich.rs
+++ b/oom-watcher/src/enrich.rs
@@ -1,0 +1,103 @@
+use oom_watcher_common::{ContainerIdentity, EnrichedOomEvent, OomKillEvent};
+
+/// Build an [`EnrichedOomEvent`] from a raw OOM kill event and an optional resolved
+/// container identity. This is the sole construction site for an enriched event.
+///
+/// It encodes one rule: `node_name` is known iff a Kubernetes client exists (the
+/// caller passes `Some`), independent of whether the container identity could be
+/// resolved. A failed resolution clears the container fields but never the node.
+pub fn enrich(
+    raw_event: OomKillEvent,
+    node_name: Option<&str>,
+    identity: Option<ContainerIdentity>,
+    timestamp: u64,
+) -> EnrichedOomEvent {
+    let (namespace, pod_name, container_name, container_id) = match identity {
+        Some(id) => (
+            Some(id.namespace),
+            Some(id.pod_name),
+            Some(id.container_name),
+            Some(id.container_id),
+        ),
+        None => (None, None, None, None),
+    };
+
+    EnrichedOomEvent {
+        raw_event,
+        node_name: node_name.map(str::to_string),
+        namespace,
+        pod_name,
+        container_name,
+        container_id,
+        timestamp,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw() -> OomKillEvent {
+        OomKillEvent {
+            pid: 1234,
+            tgid: 1200,
+            comm: *b"python\0\0\0\0\0\0\0\0\0\0",
+            total_vm: 100,
+            anon_rss: 50,
+            file_rss: 20,
+            shmem_rss: 5,
+            uid: 1000,
+            pgtables: 8,
+            oom_score_adj: 0,
+        }
+    }
+
+    fn identity() -> ContainerIdentity {
+        ContainerIdentity {
+            namespace: "prod".into(),
+            pod_name: "api-7d9".into(),
+            container_name: "api".into(),
+            container_id: "abc123".into(),
+        }
+    }
+
+    #[test]
+    fn fills_all_fields_when_identity_resolved_on_node() {
+        let e = enrich(raw(), Some("node-1"), Some(identity()), 42);
+        assert_eq!(e.node_name.as_deref(), Some("node-1"));
+        assert_eq!(e.namespace.as_deref(), Some("prod"));
+        assert_eq!(e.pod_name.as_deref(), Some("api-7d9"));
+        assert_eq!(e.container_name.as_deref(), Some("api"));
+        assert_eq!(e.container_id.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn keeps_node_when_identity_unresolved() {
+        // The load-bearing invariant: a failed resolution must not erase the node we
+        // already know we are running on.
+        let e = enrich(raw(), Some("node-1"), None, 42);
+        assert_eq!(e.node_name.as_deref(), Some("node-1"));
+        assert_eq!(e.namespace, None);
+        assert_eq!(e.pod_name, None);
+        assert_eq!(e.container_name, None);
+        assert_eq!(e.container_id, None);
+    }
+
+    #[test]
+    fn all_none_in_standalone_mode() {
+        let e = enrich(raw(), None, None, 42);
+        assert_eq!(e.node_name, None);
+        assert_eq!(e.namespace, None);
+        assert_eq!(e.pod_name, None);
+        assert_eq!(e.container_name, None);
+        assert_eq!(e.container_id, None);
+    }
+
+    #[test]
+    fn passes_raw_event_and_timestamp_through() {
+        let e = enrich(raw(), None, None, 99);
+        assert_eq!(e.timestamp, 99);
+        assert_eq!(e.raw_event.pid, 1234);
+        assert_eq!(e.raw_event.total_vm, 100);
+    }
+}

--- a/oom-watcher/src/kubernetes.rs
+++ b/oom-watcher/src/kubernetes.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{api::ListParams, Api, Client, Config};
 use log::{debug, warn};
+use oom_watcher_common::ContainerIdentity;
 use regex::Regex;
 
 pub struct KubernetesClient {
@@ -31,18 +32,11 @@ impl KubernetesClient {
         &self.node_name
     }
 
-    pub async fn get_container_info(
-        &self,
-        pid: u32,
-    ) -> Result<Option<(String, String, String, String)>> {
+    pub async fn get_container_info(&self, pid: u32) -> Result<Option<ContainerIdentity>> {
         let container_id = self.get_container_id_from_pid(pid)?;
 
         if let Some(container_id) = container_id {
-            if let Some((namespace, pod_name, container_name)) =
-                self.get_pod_info_from_container_id(&container_id).await?
-            {
-                return Ok(Some((namespace, pod_name, container_name, container_id)));
-            }
+            return self.get_pod_info_from_container_id(&container_id).await;
         }
 
         Ok(None)
@@ -85,7 +79,7 @@ impl KubernetesClient {
     async fn get_pod_info_from_container_id(
         &self,
         container_id: &str,
-    ) -> Result<Option<(String, String, String)>> {
+    ) -> Result<Option<ContainerIdentity>> {
         // Scope the query to this node so we don't list every pod in the
         // cluster on each OOM event; the kubelet supports the spec.nodeName
         // field selector for pods.
@@ -113,7 +107,12 @@ impl KubernetesClient {
                                     .unwrap_or_else(|| "unknown".to_string());
                                 let container_name = container_status.name.clone();
 
-                                return Ok(Some((namespace, pod_name, container_name)));
+                                return Ok(Some(ContainerIdentity {
+                                    namespace,
+                                    pod_name,
+                                    container_name,
+                                    container_id: container_id.to_string(),
+                                }));
                             }
                         }
                     }

--- a/oom-watcher/src/main.rs
+++ b/oom-watcher/src/main.rs
@@ -1,3 +1,4 @@
+mod enrich;
 mod kubernetes;
 mod metrics;
 
@@ -9,10 +10,11 @@ use std::{
 use axum::serve;
 use aya::{include_bytes_aligned, maps::RingBuf, programs::TracePoint, Ebpf};
 use aya_log::EbpfLogger;
+use enrich::enrich;
 use kubernetes::KubernetesClient;
 use log::{error, info, warn};
 use metrics::MetricsCollector;
-use oom_watcher_common::{EnrichedOomEvent, OomKillEvent};
+use oom_watcher_common::OomKillEvent;
 use tokio::{signal, task};
 
 #[tokio::main]
@@ -162,64 +164,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .unwrap_or_default()
                             .as_secs();
 
-                        // Enrich event with Kubernetes metadata
-                        let enriched_event = if let Some(ref client) = k8s_client {
-                            match client.get_container_info(raw_event.pid).await {
-                                Ok(Some((namespace, pod_name, container_name, container_id))) => {
-                                    EnrichedOomEvent {
-                                        raw_event,
-                                        node_name: Some(client.node_name().to_string()),
-                                        namespace: Some(namespace),
-                                        pod_name: Some(pod_name),
-                                        container_name: Some(container_name),
-                                        container_id: Some(container_id),
-                                        timestamp,
-                                    }
-                                }
+                        // Resolve the killed PID to its container identity, logging the
+                        // two failure modes distinctly, then collapse both to "no
+                        // identity". The node is known iff a client exists, regardless
+                        // of whether resolution succeeded.
+                        let node_name = k8s_client.as_ref().map(|c| c.node_name().to_string());
+                        let identity = match &k8s_client {
+                            Some(client) => match client.get_container_info(raw_event.pid).await {
+                                Ok(Some(identity)) => Some(identity),
                                 Ok(None) => {
                                     warn!(
                                         "Could not find Kubernetes info for PID {}",
                                         raw_event.pid
                                     );
-                                    EnrichedOomEvent {
-                                        raw_event,
-                                        node_name: k8s_client
-                                            .as_ref()
-                                            .map(|c| c.node_name().to_string()),
-                                        namespace: None,
-                                        pod_name: None,
-                                        container_name: None,
-                                        container_id: None,
-                                        timestamp,
-                                    }
+                                    None
                                 }
                                 Err(e) => {
                                     warn!(
                                         "Error getting Kubernetes info for PID {}: {}",
                                         raw_event.pid, e
                                     );
-                                    EnrichedOomEvent {
-                                        raw_event,
-                                        node_name: Some(client.node_name().to_string()),
-                                        namespace: None,
-                                        pod_name: None,
-                                        container_name: None,
-                                        container_id: None,
-                                        timestamp,
-                                    }
+                                    None
                                 }
-                            }
-                        } else {
-                            EnrichedOomEvent {
-                                raw_event,
-                                node_name: None,
-                                namespace: None,
-                                pod_name: None,
-                                container_name: None,
-                                container_id: None,
-                                timestamp,
-                            }
+                            },
+                            None => None,
                         };
+
+                        let enriched_event =
+                            enrich(raw_event, node_name.as_deref(), identity, timestamp);
 
                         // Record metrics
                         metrics_collector.record_oom_event(&enriched_event);


### PR DESCRIPTION
## What

Extract the per-event Kubernetes enrichment out of `main()`'s spawned event loop into a dedicated, pure `enrich()` module — the sole construction site for an `EnrichedOomEvent`.

## Why

The event loop rebuilt `EnrichedOomEvent` **four times** (resolved, `Ok(None)`, `Err`, no-client), each filling `None`s slightly differently. The arms had already drifted: the `Ok(None)` arm computed `node_name` via `k8s_client.as_ref().map(...)` while the `Err` arm used `Some(client.node_name())`. The decision was untestable — reaching it required a live kernel *and* a live cluster.

## Changes

- **`ContainerIdentity`** — named DTO replacing the unnamed `(String, String, String, String)` tuple returned by the Kubernetes lookup. Data-only, so no `anyhow` leaks into the `no_std` common crate.
- **`enrich.rs`** — `enrich(raw_event, node_name, identity, timestamp) -> EnrichedOomEvent`, pure and total. The four constructions collapse to one call; `node_name` is computed once, making the *node-known-iff-client* invariant structural. Unit tests cover the full fallback matrix with no kernel/cluster/tokio.
- **`kubernetes.rs`** — lookup returns `ContainerIdentity`; intermediate tuple-shuffling removed.
- **`CONTEXT.md`** — seeded domain glossary (OOM kill event, container identity, enrichment, resolution).

Decoupled from the resolver-seam and event-source-seam refactors, which remain open.