### PR TITLE
feat(resolve): extract Resolution behind a ContainerResolver seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,8 @@ use these terms exactly.
 
 - **Enrichment** — the step that takes a raw **OOM kill event** and a (possibly absent)
   **container identity** and produces an **enriched OOM event**. The single rule it
-  encodes: `node_name` is known *iff* this process has a Kubernetes client (i.e. we are
-  running in-cluster), regardless of whether the container identity could be resolved.
+  encodes: `node_name` is known *iff* this process has a **container resolver** (i.e. we
+  are running in-cluster), regardless of whether the container identity could be resolved.
   Lives in `oom-watcher/src/enrich.rs` as the sole construction site for an enriched
   event.
 
@@ -27,6 +27,19 @@ use these terms exactly.
   Prometheus metrics and logged.
 
 - **Resolution** — the I/O act of turning a PID into a **container identity**. Three
-  outcomes: found (`Ok(Some)`), not found (`Ok(None)`), or lookup error (`Err`). The
-  watch loop logs the two failure outcomes distinctly, then collapses both to "no
-  identity" before handing off to **enrichment**.
+  outcomes, carried by the **resolution outcome** type: found (`Found`), not found
+  (`NotFound`), or lookup error (`Failed`). The watch loop records the outcome to metrics
+  and logs the two failure outcomes distinctly, then collapses to "no identity" via
+  `ResolutionOutcome::identity()` before handing off to **enrichment**.
+
+- **Container resolver** (`ContainerResolver`) — the seam for **resolution**. A trait
+  exposing `node_name()` and `async resolve(pid) -> ResolutionOutcome`. `KubernetesClient`
+  is the in-cluster adapter (maps `Ok(Some)`→`Found`, `Ok(None)`→`NotFound`, `Err`→`Failed`);
+  a test fake is the second adapter. Held as an `Option` — `Some` iff in-cluster — which is
+  the single source of the **enrichment** `node_name` iff-rule. The watch loop is generic
+  over the resolver (static dispatch; no `dyn`).
+
+- **Resolution outcome** (`ResolutionOutcome`) — the three-variant result of **resolution**:
+  `Found(ContainerIdentity)`, `NotFound`, `Failed(anyhow::Error)`. Preserves the
+  not-found-vs-error distinction past the seam so `oom_resolution_failures_total{reason}`
+  can count them separately, where the **enrichment** collapse would otherwise discard it.

--- a/oom-watcher/src/kubernetes.rs
+++ b/oom-watcher/src/kubernetes.rs
@@ -7,6 +7,8 @@ use log::{debug, warn};
 use oom_watcher_common::ContainerIdentity;
 use regex::Regex;
 
+use crate::resolve::{ContainerResolver, ResolutionOutcome};
+
 pub struct KubernetesClient {
     pods_api: Api<Pod>,
     node_name: String,
@@ -20,16 +22,17 @@ impl KubernetesClient {
         let client = Client::try_from(config)?;
         let pods_api: Api<Pod> = Api::all(client);
 
-        let node_name = std::env::var("NODE_NAME").unwrap_or_else(|_| "unknown".to_string());
+        // Require NODE_NAME rather than defaulting to "unknown": a wrong node scopes
+        // the spec.nodeName field selector to a node with no pods, so every lookup
+        // would silently return NotFound. Failing here drops us to standalone mode.
+        let node_name = std::env::var("NODE_NAME").map_err(|_| {
+            anyhow!("NODE_NAME is unset; the DaemonSet must expose it via the downward API")
+        })?;
 
         Ok(Self {
             pods_api,
             node_name,
         })
-    }
-
-    pub fn node_name(&self) -> &str {
-        &self.node_name
     }
 
     pub async fn get_container_info(&self, pid: u32) -> Result<Option<ContainerIdentity>> {
@@ -122,5 +125,21 @@ impl KubernetesClient {
 
         warn!("Could not find pod info for container ID: {}", container_id);
         Ok(None)
+    }
+}
+
+/// The in-cluster adapter for the Resolution seam. Maps `get_container_info`'s
+/// `Result<Option<_>>` onto the three [`ResolutionOutcome`] variants.
+impl ContainerResolver for KubernetesClient {
+    fn node_name(&self) -> &str {
+        &self.node_name
+    }
+
+    async fn resolve(&self, pid: u32) -> ResolutionOutcome {
+        match self.get_container_info(pid).await {
+            Ok(Some(identity)) => ResolutionOutcome::Found(identity),
+            Ok(None) => ResolutionOutcome::NotFound,
+            Err(e) => ResolutionOutcome::Failed(e),
+        }
     }
 }

--- a/oom-watcher/src/main.rs
+++ b/oom-watcher/src/main.rs
@@ -1,6 +1,7 @@
 mod enrich;
 mod kubernetes;
 mod metrics;
+mod resolve;
 
 use std::{
     sync::Arc,
@@ -15,6 +16,7 @@ use kubernetes::KubernetesClient;
 use log::{error, info, warn};
 use metrics::MetricsCollector;
 use oom_watcher_common::OomKillEvent;
+use resolve::{ContainerResolver, ResolutionOutcome};
 use tokio::{signal, task};
 
 #[tokio::main]
@@ -164,30 +166,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .unwrap_or_default()
                             .as_secs();
 
-                        // Resolve the killed PID to its container identity, logging the
-                        // two failure modes distinctly, then collapse both to "no
-                        // identity". The node is known iff a client exists, regardless
-                        // of whether resolution succeeded.
-                        let node_name = k8s_client.as_ref().map(|c| c.node_name().to_string());
-                        let identity = match &k8s_client {
-                            Some(client) => match client.get_container_info(raw_event.pid).await {
-                                Ok(Some(identity)) => Some(identity),
-                                Ok(None) => {
-                                    warn!(
+                        // Resolve the killed PID to its container identity. Record the
+                        // outcome (so not-found and error are counted distinctly), log
+                        // the two failure modes, then collapse to "no identity". The
+                        // node is known iff a resolver exists, regardless of whether
+                        // resolution succeeded.
+                        let (node_name, identity) = match &k8s_client {
+                            Some(client) => {
+                                let outcome = client.resolve(raw_event.pid).await;
+                                metrics_collector
+                                    .record_resolution_outcome(client.node_name(), &outcome);
+                                match &outcome {
+                                    ResolutionOutcome::NotFound => warn!(
                                         "Could not find Kubernetes info for PID {}",
                                         raw_event.pid
-                                    );
-                                    None
-                                }
-                                Err(e) => {
-                                    warn!(
+                                    ),
+                                    ResolutionOutcome::Failed(e) => warn!(
                                         "Error getting Kubernetes info for PID {}: {}",
                                         raw_event.pid, e
-                                    );
-                                    None
+                                    ),
+                                    ResolutionOutcome::Found(_) => {}
                                 }
-                            },
-                            None => None,
+                                (Some(client.node_name().to_string()), outcome.identity())
+                            }
+                            None => (None, None),
                         };
 
                         let enriched_event =

--- a/oom-watcher/src/metrics.rs
+++ b/oom-watcher/src/metrics.rs
@@ -4,6 +4,8 @@ use axum::{extract::State, http::StatusCode, response::Response, routing::get, R
 use oom_watcher_common::EnrichedOomEvent;
 use prometheus::{CounterVec, GaugeVec, Registry, TextEncoder};
 
+use crate::resolve::ResolutionOutcome;
+
 #[derive(Clone)]
 pub struct MetricsCollector {
     registry: Registry,
@@ -11,6 +13,7 @@ pub struct MetricsCollector {
     oom_kills_per_node_total: CounterVec,
     oom_memory_usage_bytes: GaugeVec,
     oom_last_timestamp: GaugeVec,
+    oom_resolution_failures_total: CounterVec,
 }
 
 impl MetricsCollector {
@@ -47,6 +50,15 @@ impl MetricsCollector {
         )
         .expect("Failed to create oom_last_timestamp metric");
 
+        let oom_resolution_failures_total = CounterVec::new(
+            prometheus::Opts::new(
+                "oom_resolution_failures_total",
+                "OOM events whose PID could not be resolved to a container, by reason",
+            ),
+            &["node", "reason"],
+        )
+        .expect("Failed to create oom_resolution_failures_total metric");
+
         registry
             .register(Box::new(oom_kills_total.clone()))
             .expect("Failed to register oom_kills_total");
@@ -59,6 +71,9 @@ impl MetricsCollector {
         registry
             .register(Box::new(oom_last_timestamp.clone()))
             .expect("Failed to register oom_last_timestamp");
+        registry
+            .register(Box::new(oom_resolution_failures_total.clone()))
+            .expect("Failed to register oom_resolution_failures_total");
 
         Self {
             registry,
@@ -66,6 +81,7 @@ impl MetricsCollector {
             oom_kills_per_node_total,
             oom_memory_usage_bytes,
             oom_last_timestamp,
+            oom_resolution_failures_total,
         }
     }
 
@@ -110,6 +126,20 @@ impl MetricsCollector {
             .set(event.timestamp as f64);
     }
 
+    /// Count a resolution that did not yield a container identity, keyed by reason
+    /// (`not_found` vs `error`). A `Found` outcome is a no-op — successes are implicit
+    /// in `oom_kills_total`, so the failure rate is `failures / kills` in PromQL.
+    pub fn record_resolution_outcome(&self, node: &str, outcome: &ResolutionOutcome) {
+        let reason = match outcome {
+            ResolutionOutcome::Found(_) => return,
+            ResolutionOutcome::NotFound => "not_found",
+            ResolutionOutcome::Failed(_) => "error",
+        };
+        self.oom_resolution_failures_total
+            .with_label_values(&[node, reason])
+            .inc();
+    }
+
     pub fn get_metrics(&self) -> String {
         let encoder = TextEncoder::new();
         let metric_families = self.registry.gather();
@@ -133,4 +163,35 @@ async fn metrics_handler(
         .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
         .body(metrics)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_failures_by_reason_and_ignores_found() {
+        let collector = MetricsCollector::new();
+
+        collector.record_resolution_outcome("node-1", &ResolutionOutcome::NotFound);
+        collector.record_resolution_outcome("node-1", &ResolutionOutcome::NotFound);
+        collector
+            .record_resolution_outcome("node-1", &ResolutionOutcome::Failed(anyhow::anyhow!("x")));
+        // Found must not touch the failures counter.
+        collector.record_resolution_outcome(
+            "node-1",
+            &ResolutionOutcome::Found(oom_watcher_common::ContainerIdentity {
+                namespace: "p".into(),
+                pod_name: "po".into(),
+                container_name: "c".into(),
+                container_id: "id".into(),
+            }),
+        );
+
+        let out = collector.get_metrics();
+        assert!(
+            out.contains("oom_resolution_failures_total{node=\"node-1\",reason=\"not_found\"} 2")
+        );
+        assert!(out.contains("oom_resolution_failures_total{node=\"node-1\",reason=\"error\"} 1"));
+    }
 }

--- a/oom-watcher/src/resolve.rs
+++ b/oom-watcher/src/resolve.rs
@@ -1,0 +1,138 @@
+//! The Resolution seam: turning a killed PID into a container identity.
+//!
+//! `Resolution` is the I/O act of mapping a PID to the Kubernetes container that
+//! owned it. [`ContainerResolver`] is the seam it lives behind, and
+//! [`ResolutionOutcome`] is what crosses that seam — preserving the
+//! not-found-vs-error distinction the enrichment collapse would otherwise discard.
+
+use oom_watcher_common::ContainerIdentity;
+
+/// The three outcomes of resolving a PID to a container identity.
+///
+/// Keeping `NotFound` and `Failed` distinct past the seam lets metrics count them
+/// separately; [`identity`](Self::identity) is where both collapse to "no identity"
+/// for enrichment.
+#[derive(Debug)]
+pub enum ResolutionOutcome {
+    /// A pod on this node owns the killed process.
+    Found(ContainerIdentity),
+    /// We looked but no pod matched — the process is not in a container, or it was
+    /// already reaped before we could read its cgroup.
+    NotFound,
+    /// The lookup itself failed: proc read, regex, or Kubernetes API error.
+    Failed(anyhow::Error),
+}
+
+impl ResolutionOutcome {
+    /// Collapse to the shape [`enrich`](crate::enrich::enrich) consumes: an identity
+    /// iff resolution found one. Both failure modes become "no identity".
+    pub fn identity(self) -> Option<ContainerIdentity> {
+        match self {
+            Self::Found(identity) => Some(identity),
+            Self::NotFound | Self::Failed(_) => None,
+        }
+    }
+}
+
+/// The seam for Resolution: turn a killed PID into a [`ResolutionOutcome`].
+///
+/// `KubernetesClient` is the in-cluster adapter; tests use a fake. The watch loop
+/// holds an `Option<impl ContainerResolver>` — `Some` iff in-cluster — which is the
+/// single source of the enrichment `node_name` iff-rule.
+// Static dispatch only (the loop is generic over a concrete resolver, never `dyn`),
+// so the missing-`Send`-bound concern the lint guards against does not apply.
+#[allow(async_fn_in_trait)]
+pub trait ContainerResolver {
+    /// The node this resolver is scoped to — known because we are in-cluster.
+    fn node_name(&self) -> &str;
+
+    /// Resolve a PID to its container identity. Never surfaces an error directly;
+    /// failures are carried as [`ResolutionOutcome::Failed`] so callers handle all
+    /// three outcomes through one match.
+    async fn resolve(&self, pid: u32) -> ResolutionOutcome;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> ContainerIdentity {
+        ContainerIdentity {
+            namespace: "prod".into(),
+            pod_name: "api-7d9".into(),
+            container_name: "api".into(),
+            container_id: "abc123".into(),
+        }
+    }
+
+    #[test]
+    fn identity_is_some_only_when_found() {
+        assert_eq!(
+            ResolutionOutcome::Found(identity()).identity(),
+            Some(identity())
+        );
+        assert_eq!(ResolutionOutcome::NotFound.identity(), None);
+        assert_eq!(
+            ResolutionOutcome::Failed(anyhow::anyhow!("boom")).identity(),
+            None
+        );
+    }
+
+    /// A second adapter — proving the seam is real, not hypothetical. Reused as the
+    /// test harness once the watch loop is extracted (candidate 1).
+    enum Behavior {
+        Found(ContainerIdentity),
+        NotFound,
+        Fail,
+    }
+
+    struct FakeResolver {
+        node: String,
+        behavior: Behavior,
+    }
+
+    impl ContainerResolver for FakeResolver {
+        fn node_name(&self) -> &str {
+            &self.node
+        }
+
+        async fn resolve(&self, _pid: u32) -> ResolutionOutcome {
+            match &self.behavior {
+                Behavior::Found(id) => ResolutionOutcome::Found(id.clone()),
+                Behavior::NotFound => ResolutionOutcome::NotFound,
+                Behavior::Fail => ResolutionOutcome::Failed(anyhow::anyhow!("api down")),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fake_resolver_yields_each_outcome() {
+        let found = FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::Found(identity()),
+        };
+        assert_eq!(found.node_name(), "node-1");
+        assert!(matches!(
+            found.resolve(1234).await,
+            ResolutionOutcome::Found(_)
+        ));
+
+        let missing = FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::NotFound,
+        };
+        assert!(matches!(
+            missing.resolve(1234).await,
+            ResolutionOutcome::NotFound
+        ));
+
+        let broken = FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::Fail,
+        };
+        assert!(matches!(
+            broken.resolve(1234).await,
+            ResolutionOutcome::Failed(_)
+        ));
+    }
+}


### PR DESCRIPTION
## What

Turns **Resolution** (PID → container identity) into a real module behind a seam, and stops the watch loop from discarding the failure-mode distinction the domain treats as meaningful.

- **`resolve.rs`** — new `ContainerResolver` trait (the seam) and `ResolutionOutcome { Found, NotFound, Failed(anyhow::Error) }` (what crosses it), with a pure `identity()` collapse. Static dispatch (no `dyn`).
- **`kubernetes.rs`** — `KubernetesClient` becomes the in-cluster adapter (`Ok(Some)`→`Found`, `Ok(None)`→`NotFound`, `Err`→`Failed`); a test fake is the second adapter, making the seam real rather than hypothetical.
- **`metrics.rs`** — new `oom_resolution_failures_total{node, reason}` counter; the `not_found` vs `error` distinction is now queryable instead of collapsed before metrics see it.
- **watch loop** — resolve → record outcome → distinct logging → `identity()` collapse → `enrich`. Unchanged enrichment contract; `enrich.rs` stays the sole construction site.

## Why

The previous inline `match` against a concrete client had one adapter and was untestable without a live cluster, and both failure modes were collapsed to `None` before metrics — so an API outage and a genuinely-unmatched PID were indistinguishable.

## Breaking / behavioural change

`KubernetesClient::new()` now **requires `NODE_NAME`**. Previously it defaulted to `"unknown"`, which scoped the `spec.nodeName` field selector to a node with no pods — every lookup became a false `NotFound`. A missing `NODE_NAME` now drops the process to standalone mode (node reported as unknown, no broken queries). The DaemonSet already injects `NODE_NAME` via the downward API.