### PR TITLE
refactor(watch): extract the watch loop behind testable seams

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,18 +28,40 @@ use these terms exactly.
 
 - **Resolution** — the I/O act of turning a PID into a **container identity**. Three
   outcomes, carried by the **resolution outcome** type: found (`Found`), not found
-  (`NotFound`), or lookup error (`Failed`). The watch loop records the outcome to metrics
-  and logs the two failure outcomes distinctly, then collapses to "no identity" via
-  `ResolutionOutcome::identity()` before handing off to **enrichment**.
+  (`NotFound`), or lookup error (`Failed`). The **watch loop** records the outcome to the
+  **metrics recorder** and logs the two failure outcomes distinctly, then collapses to
+  "no identity" via `ResolutionOutcome::identity()` before handing off to **enrichment**.
 
 - **Container resolver** (`ContainerResolver`) — the seam for **resolution**. A trait
   exposing `node_name()` and `async resolve(pid) -> ResolutionOutcome`. `KubernetesClient`
   is the in-cluster adapter (maps `Ok(Some)`→`Found`, `Ok(None)`→`NotFound`, `Err`→`Failed`);
   a test fake is the second adapter. Held as an `Option` — `Some` iff in-cluster — which is
-  the single source of the **enrichment** `node_name` iff-rule. The watch loop is generic
+  the single source of the **enrichment** `node_name` iff-rule. The **watch loop** is generic
   over the resolver (static dispatch; no `dyn`).
 
 - **Resolution outcome** (`ResolutionOutcome`) — the three-variant result of **resolution**:
   `Found(ContainerIdentity)`, `NotFound`, `Failed(anyhow::Error)`. Preserves the
   not-found-vs-error distinction past the seam so `oom_resolution_failures_total{reason}`
   can count them separately, where the **enrichment** collapse would otherwise discard it.
+
+- **Watch loop** (`watch::run`) — the module that owns the per-event pipeline: pull an
+  **OOM kill event** from an **OOM event source**, run **resolution** (recording the
+  **resolution outcome**), **enrich**, then record the **enriched OOM event** to the
+  **metrics recorder**. Generic over all three seams (source, resolver, recorder) plus an
+  injected clock (`now: impl Fn() -> u64`); static dispatch, no `dyn`. Loops until the
+  source ends — which a real source never does, so in production the loop runs forever and
+  `main`'s `tokio::select!` supervises and aborts it. A finite test source drives the whole
+  loop to completion, making the pipeline the test surface.
+
+- **OOM event source** (`OomEventSource`) — the seam for where **OOM kill events** reach
+  userspace. A trait exposing `async next(&mut self) -> Option<OomKillEvent>`; `None` means
+  the stream has ended. `RingBufSource` is the in-cluster adapter — it owns the eBPF ring
+  buffer, performs the single `unsafe` decode (`read_unaligned` + short-read guard), and
+  hides the drain/100 ms-poll so it only yields whole events and never returns `None`.
+  `VecSource` (test) and `ParkSource` (non-eBPF build; parks forever) are the other adapters.
+
+- **Metrics recorder** (`MetricsRecorder`) — the seam for recording, decoupling the **watch
+  loop** from Prometheus. A trait exposing `record_resolution_outcome(node, &outcome)` and
+  `record_oom_event(&enriched)`. `MetricsCollector` is the Prometheus adapter (recording
+  only — HTTP serving lives in the `http` module so axum no longer leaks through its
+  interface); a test spy is the second adapter.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,6 @@ dependencies = [
 [[package]]
 name = "oom-watcher-common"
 version = "0.1.0"
-dependencies = [
- "aya",
-]
 
 [[package]]
 name = "oom-watcher-ebpf"

--- a/oom-watcher-common/Cargo.toml
+++ b/oom-watcher-common/Cargo.toml
@@ -7,10 +7,9 @@ license.workspace = true
 
 [features]
 default = []
-user = ["aya"]
-
-[dependencies]
-aya = { workspace = true, optional = true }
+# `user` enables the std-backed fields (String identities) for the userspace crate. The
+# shared types are plain #[repr(C)] structs — no aya dependency is needed on either side.
+user = []
 
 [lib]
 path = "src/lib.rs"

--- a/oom-watcher/Cargo.toml
+++ b/oom-watcher/Cargo.toml
@@ -7,17 +7,19 @@ license.workspace = true
 
 [features]
 default = ["ebpf"]
-ebpf = []
+# The eBPF probe is Linux-only (aya pulls in Linux syscalls). Gating it keeps the
+# testable core (watch loop, recorder, enrichment, resolution) buildable on any platform.
+ebpf = ["dep:aya", "dep:aya-log", "dep:libc"]
 
 [dependencies]
 bytes = "1.11"
 oom-watcher-common = { path = "../oom-watcher-common", features = ["user"] }
 
 anyhow = { workspace = true, default-features = true }
-aya = { workspace = true, features = ["async_tokio"], default-features = true }
-aya-log = { workspace = true }
+aya = { workspace = true, features = ["async_tokio"], default-features = true, optional = true }
+aya-log = { workspace = true, optional = true }
 env_logger = { workspace = true }
-libc = { workspace = true }
+libc = { workspace = true, optional = true }
 log = { workspace = true }
 tokio = { workspace = true, features = [
     "macros",

--- a/oom-watcher/src/http.rs
+++ b/oom-watcher/src/http.rs
@@ -1,0 +1,25 @@
+//! The metrics HTTP surface. Confines axum to one module so the [`MetricsCollector`]
+//! interface stays Prometheus-only — the watch loop and `main` never touch axum types.
+
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::Response, routing::get, Router};
+
+use crate::metrics::MetricsCollector;
+
+/// Build the `/metrics` router backed by `collector`.
+pub fn router(collector: Arc<MetricsCollector>) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(collector)
+}
+
+async fn metrics_handler(
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Result<Response<String>, StatusCode> {
+    let metrics = collector.get_metrics();
+    Response::builder()
+        .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
+        .body(metrics)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}

--- a/oom-watcher/src/main.rs
+++ b/oom-watcher/src/main.rs
@@ -1,31 +1,36 @@
 mod enrich;
+mod http;
 mod kubernetes;
 mod metrics;
 mod resolve;
+mod source;
+mod watch;
 
 use std::{
     sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
+use anyhow::anyhow;
 use axum::serve;
-use aya::{include_bytes_aligned, maps::RingBuf, programs::TracePoint, Ebpf};
-use aya_log::EbpfLogger;
-use enrich::enrich;
 use kubernetes::KubernetesClient;
 use log::{error, info, warn};
 use metrics::MetricsCollector;
-use oom_watcher_common::OomKillEvent;
-use resolve::{ContainerResolver, ResolutionOutcome};
+use resolve::ContainerResolver;
+#[cfg(not(feature = "ebpf"))]
+use source::ParkSource;
+#[cfg(feature = "ebpf")]
+use source::RingBufSource;
 use tokio::{signal, task};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     info!("Starting OOM Watcher with Kubernetes and Prometheus integration...");
 
-    // Initialize Kubernetes client
+    // Resolver for the watch loop: Some iff in-cluster. A failure drops us to standalone
+    // mode (no node, no container identity) rather than aborting startup.
     let k8s_client = match KubernetesClient::new().await {
         Ok(client) => {
             info!(
@@ -43,91 +48,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Initialize Prometheus metrics collector
+    // Metrics recorder + its HTTP surface.
     let metrics_collector = Arc::new(MetricsCollector::new());
-
-    // Start Prometheus metrics server
     let metrics_port = std::env::var("METRICS_PORT")
         .unwrap_or_else(|_| "8080".to_string())
         .parse::<u16>()
         .unwrap_or(8080);
 
-    let app = metrics_collector.clone().create_server(metrics_port);
-
-    // Bind before spawning so a bind failure fails startup loudly, instead of
-    // panicking inside a detached task and leaving the process running blind.
+    // Bind before spawning so a bind failure fails startup loudly, instead of panicking
+    // inside a detached task and leaving the process running blind.
     info!(
         "Starting Prometheus metrics server on port {}",
         metrics_port
     );
     let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", metrics_port)).await?;
-
+    let app = http::router(metrics_collector.clone());
     let mut metrics_server = task::spawn(async move {
         if let Err(e) = serve(listener, app).await {
             error!("Metrics server error: {}", e);
         }
     });
 
-    // Bump the memlock rlimit. This is needed for older kernels that don't use the
-    // new memcg based accounting, see https://lwn.net/Articles/837122/
-    let rlim = libc::rlimit {
-        rlim_cur: libc::RLIM_INFINITY,
-        rlim_max: libc::RLIM_INFINITY,
-    };
-    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
-    if ret != 0 {
-        warn!("remove limit on locked memory failed, ret is: {}", ret);
-    }
-
-    // Load eBPF program
+    // Event source: the eBPF probe in-cluster, a parking source for non-eBPF builds. All
+    // aya/ring-buffer handling lives behind the OomEventSource seam.
     #[cfg(feature = "ebpf")]
-    let mut bpf = {
-        #[cfg(debug_assertions)]
-        let bpf = Ebpf::load(include_bytes_aligned!(
-            "../../target/bpfel-unknown-none/release/oom-watcher-ebpf"
-        ))?;
-        #[cfg(not(debug_assertions))]
-        let bpf = Ebpf::load(include_bytes_aligned!(concat!(
-            env!("OUT_DIR"),
-            "/oom-watcher-ebpf-object"
-        )))?;
-        bpf
-    };
-
-    #[cfg(feature = "ebpf")]
-    {
-        info!("eBPF program loaded successfully");
-
-        if let Err(e) = EbpfLogger::init(&mut bpf) {
-            warn!("failed to initialize eBPF logger: {}", e);
-        }
-
-        let program: &mut TracePoint = bpf
-            .program_mut("mark_victim")
-            .ok_or("Could not find eBPF program 'mark_victim'")?
-            .try_into()?;
-
-        info!("Loading eBPF program (tracepoint 'oom:mark_victim')...");
-        if let Err(e) = program.load() {
-            error!("Failed to load eBPF program: {}", e);
-            return Err(e.into());
-        }
-
-        info!("Attaching to tracepoint oom:mark_victim...");
-        if let Err(e) = program.attach("oom", "mark_victim") {
-            error!("Failed to attach to tracepoint oom:mark_victim: {}", e);
-            error!("This might mean:");
-            error!("  1. The tracepoint 'oom:mark_victim' isn't available on this kernel");
-            error!("  2. Insufficient permissions (try running as root)");
-            return Err(e.into());
-        }
-        info!("Successfully attached to tracepoint oom:mark_victim");
-    }
-
+    let source = RingBufSource::new()?;
     #[cfg(not(feature = "ebpf"))]
-    {
-        info!("eBPF functionality disabled - running in test mode");
-    }
+    let source = ParkSource;
 
     info!("🔍 OOM Watcher is now active and monitoring for OOM events...");
     info!(
@@ -136,118 +83,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     info!("⏹️  Press Ctrl-C to stop monitoring");
 
-    // Main event processing loop
+    // The watch loop owns the source and resolver and borrows the recorder for the life of
+    // the task. It loops forever in production; the select! below supervises and aborts it.
+    let recorder = metrics_collector.clone();
     let mut event_processor = task::spawn(async move {
-        #[cfg(feature = "ebpf")]
-        {
-            let events_map = match bpf.map_mut("EVENTS") {
-                Some(map) => map,
-                None => {
-                    error!("Could not find eBPF map 'EVENTS'; event processor stopping");
-                    return;
-                }
-            };
-            let mut ring_buf = match RingBuf::try_from(events_map) {
-                Ok(ring_buf) => ring_buf,
-                Err(e) => {
-                    error!("Failed to open 'EVENTS' ring buffer: {}", e);
-                    return;
-                }
-            };
-            loop {
-                while let Some(item) = ring_buf.next() {
-                    let data: &[u8] = &item;
-                    if data.len() >= core::mem::size_of::<OomKillEvent>() {
-                        let ptr = data.as_ptr() as *const OomKillEvent;
-                        let raw_event = unsafe { ptr.read_unaligned() };
-
-                        let timestamp = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs();
-
-                        // Resolve the killed PID to its container identity. Record the
-                        // outcome (so not-found and error are counted distinctly), log
-                        // the two failure modes, then collapse to "no identity". The
-                        // node is known iff a resolver exists, regardless of whether
-                        // resolution succeeded.
-                        let (node_name, identity) = match &k8s_client {
-                            Some(client) => {
-                                let outcome = client.resolve(raw_event.pid).await;
-                                metrics_collector
-                                    .record_resolution_outcome(client.node_name(), &outcome);
-                                match &outcome {
-                                    ResolutionOutcome::NotFound => warn!(
-                                        "Could not find Kubernetes info for PID {}",
-                                        raw_event.pid
-                                    ),
-                                    ResolutionOutcome::Failed(e) => warn!(
-                                        "Error getting Kubernetes info for PID {}: {}",
-                                        raw_event.pid, e
-                                    ),
-                                    ResolutionOutcome::Found(_) => {}
-                                }
-                                (Some(client.node_name().to_string()), outcome.identity())
-                            }
-                            None => (None, None),
-                        };
-
-                        let enriched_event =
-                            enrich(raw_event, node_name.as_deref(), identity, timestamp);
-
-                        // Record metrics
-                        metrics_collector.record_oom_event(&enriched_event);
-
-                        // Log the event
-                        let comm_str = std::str::from_utf8(&raw_event.comm)
-                            .unwrap_or("?")
-                            .trim_end_matches('\0');
-
-                        info!("🚨 OOM EVENT DETECTED:");
-                        info!("   Process: {} (PID: {})", comm_str, raw_event.pid);
-                        if let Some(ref ns) = enriched_event.namespace {
-                            info!(
-                                "   Kubernetes: {}/{}/{}",
-                                ns,
-                                enriched_event.pod_name.as_deref().unwrap_or("unknown"),
-                                enriched_event
-                                    .container_name
-                                    .as_deref()
-                                    .unwrap_or("unknown")
-                            );
-                        }
-                        info!(
-                            "   Memory: total-vm={}kB anon-rss={}kB file-rss={}kB shmem-rss={}kB",
-                            raw_event.total_vm,
-                            raw_event.anon_rss,
-                            raw_event.file_rss,
-                            raw_event.shmem_rss
-                        );
-                        info!(
-                            "   User: UID={} pgtables={}kB oom_score_adj={}",
-                            raw_event.uid, raw_event.pgtables, raw_event.oom_score_adj
-                        );
-                    } else {
-                        warn!("Received short event: {} bytes", data.len());
-                    }
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        }
-
-        #[cfg(not(feature = "ebpf"))]
-        {
-            // In non-eBPF mode, just sleep and wait for shutdown
-            loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        }
+        watch::run(source, k8s_client, recorder.as_ref(), wall_clock_secs).await;
     });
 
-    // Run until shutdown is requested or a worker task exits unexpectedly. If a
-    // worker dies, return an error so the process exits non-zero and the
-    // DaemonSet restarts the pod, rather than staying up but no longer watching.
-    let outcome: Result<(), Box<dyn std::error::Error>> = tokio::select! {
+    // Run until shutdown is requested or a worker task exits unexpectedly. If a worker
+    // dies, return an error so the process exits non-zero and the DaemonSet restarts the
+    // pod, rather than staying up but no longer watching.
+    let outcome: anyhow::Result<()> = tokio::select! {
         res = signal::ctrl_c() => {
             res?;
             info!("Shutting down OOM Watcher...");
@@ -255,11 +101,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         res = &mut event_processor => {
             error!("Event processor task exited unexpectedly: {:?}", res);
-            Err("event processor task exited".into())
+            Err(anyhow!("event processor task exited"))
         }
         res = &mut metrics_server => {
             error!("Metrics server task exited unexpectedly: {:?}", res);
-            Err("metrics server task exited".into())
+            Err(anyhow!("metrics server task exited"))
         }
     };
 
@@ -267,4 +113,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     metrics_server.abort();
 
     outcome
+}
+
+/// Wall-clock seconds since the Unix epoch — the clock injected into the watch loop.
+fn wall_clock_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }

--- a/oom-watcher/src/metrics.rs
+++ b/oom-watcher/src/metrics.rs
@@ -1,11 +1,23 @@
-use std::sync::Arc;
-
-use axum::{extract::State, http::StatusCode, response::Response, routing::get, Router};
 use oom_watcher_common::EnrichedOomEvent;
 use prometheus::{CounterVec, GaugeVec, Registry, TextEncoder};
 
 use crate::resolve::ResolutionOutcome;
 
+/// The recording seam: how the watch loop reports what it observed, decoupled from
+/// Prometheus. The loop depends on this trait, never on the metrics backend.
+///
+/// `MetricsCollector` is the Prometheus adapter; tests use a spy as the second adapter.
+pub trait MetricsRecorder {
+    /// Count a resolution that did not yield a container identity, keyed by reason.
+    fn record_resolution_outcome(&self, node: &str, outcome: &ResolutionOutcome);
+
+    /// Record an enriched OOM event: kill counts, memory gauges, and timestamp.
+    fn record_oom_event(&self, event: &EnrichedOomEvent);
+}
+
+/// The Prometheus adapter for the [`MetricsRecorder`] seam. Owns the registry and the
+/// metric families; HTTP serving lives in [`crate::http`] so axum does not leak through
+/// this interface.
 #[derive(Clone)]
 pub struct MetricsCollector {
     registry: Registry,
@@ -85,7 +97,31 @@ impl MetricsCollector {
         }
     }
 
-    pub fn record_oom_event(&self, event: &EnrichedOomEvent) {
+    /// Render the registry in the Prometheus text exposition format.
+    pub fn get_metrics(&self) -> String {
+        let encoder = TextEncoder::new();
+        let metric_families = self.registry.gather();
+        encoder
+            .encode_to_string(&metric_families)
+            .unwrap_or_default()
+    }
+}
+
+impl MetricsRecorder for MetricsCollector {
+    /// A `Found` outcome is a no-op — successes are implicit in `oom_kills_total`, so the
+    /// failure rate is `failures / kills` in PromQL.
+    fn record_resolution_outcome(&self, node: &str, outcome: &ResolutionOutcome) {
+        let reason = match outcome {
+            ResolutionOutcome::Found(_) => return,
+            ResolutionOutcome::NotFound => "not_found",
+            ResolutionOutcome::Failed(_) => "error",
+        };
+        self.oom_resolution_failures_total
+            .with_label_values(&[node, reason])
+            .inc();
+    }
+
+    fn record_oom_event(&self, event: &EnrichedOomEvent) {
         let node = event.node_name.as_deref().unwrap_or("unknown");
         let namespace = event.namespace.as_deref().unwrap_or("unknown");
         let pod = event.pod_name.as_deref().unwrap_or("unknown");
@@ -125,44 +161,6 @@ impl MetricsCollector {
             .with_label_values(&[node, namespace, pod, container])
             .set(event.timestamp as f64);
     }
-
-    /// Count a resolution that did not yield a container identity, keyed by reason
-    /// (`not_found` vs `error`). A `Found` outcome is a no-op — successes are implicit
-    /// in `oom_kills_total`, so the failure rate is `failures / kills` in PromQL.
-    pub fn record_resolution_outcome(&self, node: &str, outcome: &ResolutionOutcome) {
-        let reason = match outcome {
-            ResolutionOutcome::Found(_) => return,
-            ResolutionOutcome::NotFound => "not_found",
-            ResolutionOutcome::Failed(_) => "error",
-        };
-        self.oom_resolution_failures_total
-            .with_label_values(&[node, reason])
-            .inc();
-    }
-
-    pub fn get_metrics(&self) -> String {
-        let encoder = TextEncoder::new();
-        let metric_families = self.registry.gather();
-        encoder
-            .encode_to_string(&metric_families)
-            .unwrap_or_default()
-    }
-
-    pub fn create_server(self: Arc<Self>, _port: u16) -> Router {
-        Router::new()
-            .route("/metrics", get(metrics_handler))
-            .with_state(self)
-    }
-}
-
-async fn metrics_handler(
-    State(collector): State<Arc<MetricsCollector>>,
-) -> Result<Response<String>, StatusCode> {
-    let metrics = collector.get_metrics();
-    Response::builder()
-        .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
-        .body(metrics)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
 
 #[cfg(test)]

--- a/oom-watcher/src/resolve.rs
+++ b/oom-watcher/src/resolve.rs
@@ -52,6 +52,36 @@ pub trait ContainerResolver {
     async fn resolve(&self, pid: u32) -> ResolutionOutcome;
 }
 
+/// A second adapter for the Resolution seam — proving the seam is real, and the harness
+/// the watch loop (candidate 1) is exercised through. Compiled only under test.
+#[cfg(test)]
+pub(crate) enum Behavior {
+    Found(ContainerIdentity),
+    NotFound,
+    Fail,
+}
+
+#[cfg(test)]
+pub(crate) struct FakeResolver {
+    pub(crate) node: String,
+    pub(crate) behavior: Behavior,
+}
+
+#[cfg(test)]
+impl ContainerResolver for FakeResolver {
+    fn node_name(&self) -> &str {
+        &self.node
+    }
+
+    async fn resolve(&self, _pid: u32) -> ResolutionOutcome {
+        match &self.behavior {
+            Behavior::Found(id) => ResolutionOutcome::Found(id.clone()),
+            Behavior::NotFound => ResolutionOutcome::NotFound,
+            Behavior::Fail => ResolutionOutcome::Failed(anyhow::anyhow!("api down")),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,33 +106,6 @@ mod tests {
             ResolutionOutcome::Failed(anyhow::anyhow!("boom")).identity(),
             None
         );
-    }
-
-    /// A second adapter — proving the seam is real, not hypothetical. Reused as the
-    /// test harness once the watch loop is extracted (candidate 1).
-    enum Behavior {
-        Found(ContainerIdentity),
-        NotFound,
-        Fail,
-    }
-
-    struct FakeResolver {
-        node: String,
-        behavior: Behavior,
-    }
-
-    impl ContainerResolver for FakeResolver {
-        fn node_name(&self) -> &str {
-            &self.node
-        }
-
-        async fn resolve(&self, _pid: u32) -> ResolutionOutcome {
-            match &self.behavior {
-                Behavior::Found(id) => ResolutionOutcome::Found(id.clone()),
-                Behavior::NotFound => ResolutionOutcome::NotFound,
-                Behavior::Fail => ResolutionOutcome::Failed(anyhow::anyhow!("api down")),
-            }
-        }
     }
 
     #[tokio::test]

--- a/oom-watcher/src/source.rs
+++ b/oom-watcher/src/source.rs
@@ -1,0 +1,145 @@
+//! Adapters for the OOM event source seam.
+//!
+//! `RingBufSource` is the in-cluster adapter: it owns the entire eBPF lifecycle — bumping
+//! the memlock rlimit, loading the probe, attaching it to `oom:mark_victim`, and draining
+//! the ring buffer — and performs the single `unsafe` decode of raw bytes into an
+//! `OomKillEvent`. It is the only place `aya` is referenced, which is why `aya`/`aya-log`/
+//! `libc` are optional deps gated on the `ebpf` feature. `ParkSource` is the no-op adapter
+//! for builds without that feature.
+
+#[cfg(feature = "ebpf")]
+mod ebpf_source {
+    use std::time::Duration;
+
+    use anyhow::{anyhow, Result};
+    use aya::{
+        include_bytes_aligned,
+        maps::{MapData, RingBuf},
+        programs::TracePoint,
+        Ebpf,
+    };
+    use aya_log::EbpfLogger;
+    use log::{error, info, warn};
+    use oom_watcher_common::OomKillEvent;
+
+    use crate::watch::OomEventSource;
+
+    /// The in-cluster adapter for [`OomEventSource`]. Holds the loaded eBPF program (so the
+    /// tracepoint stays attached for the source's lifetime) and owns the ring buffer.
+    pub struct RingBufSource {
+        // Keeps the program attached; never read directly.
+        _bpf: Ebpf,
+        ring_buf: RingBuf<MapData>,
+    }
+
+    impl RingBufSource {
+        /// Bring up the probe end to end: bump the memlock rlimit, load the eBPF object,
+        /// attach to `oom:mark_victim`, and take ownership of the `EVENTS` ring buffer.
+        pub fn new() -> Result<Self> {
+            bump_memlock_rlimit();
+
+            #[cfg(debug_assertions)]
+            let mut bpf = Ebpf::load(include_bytes_aligned!(
+                "../../target/bpfel-unknown-none/release/oom-watcher-ebpf"
+            ))?;
+            #[cfg(not(debug_assertions))]
+            let mut bpf = Ebpf::load(include_bytes_aligned!(concat!(
+                env!("OUT_DIR"),
+                "/oom-watcher-ebpf-object"
+            )))?;
+            info!("eBPF program loaded successfully");
+
+            if let Err(e) = EbpfLogger::init(&mut bpf) {
+                warn!("failed to initialize eBPF logger: {}", e);
+            }
+
+            let program: &mut TracePoint = bpf
+                .program_mut("mark_victim")
+                .ok_or_else(|| anyhow!("Could not find eBPF program 'mark_victim'"))?
+                .try_into()?;
+
+            info!("Loading eBPF program (tracepoint 'oom:mark_victim')...");
+            program.load()?;
+
+            info!("Attaching to tracepoint oom:mark_victim...");
+            if let Err(e) = program.attach("oom", "mark_victim") {
+                error!("Failed to attach to tracepoint oom:mark_victim: {}", e);
+                error!("This might mean:");
+                error!("  1. The tracepoint 'oom:mark_victim' isn't available on this kernel");
+                error!("  2. Insufficient permissions (try running as root)");
+                return Err(e.into());
+            }
+            info!("Successfully attached to tracepoint oom:mark_victim");
+
+            let map = bpf
+                .take_map("EVENTS")
+                .ok_or_else(|| anyhow!("Could not find eBPF map 'EVENTS'"))?;
+            let ring_buf = RingBuf::try_from(map)?;
+
+            Ok(Self {
+                _bpf: bpf,
+                ring_buf,
+            })
+        }
+    }
+
+    impl OomEventSource for RingBufSource {
+        async fn next(&mut self) -> Option<OomKillEvent> {
+            // Drain everything currently available, then poll. A real probe never ends, so
+            // this never returns None; the watch loop is stopped by aborting its task.
+            loop {
+                while let Some(item) = self.ring_buf.next() {
+                    let data: &[u8] = &item;
+                    if data.len() >= core::mem::size_of::<OomKillEvent>() {
+                        // The eBPF side writes exactly one #[repr(C)] OomKillEvent per entry.
+                        let ptr = data.as_ptr() as *const OomKillEvent;
+                        let event = unsafe { ptr.read_unaligned() };
+                        return Some(event);
+                    }
+                    warn!("Received short event: {} bytes", data.len());
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+
+    fn bump_memlock_rlimit() {
+        // Needed for older kernels without memcg-based accounting; see
+        // https://lwn.net/Articles/837122/
+        let rlim = libc::rlimit {
+            rlim_cur: libc::RLIM_INFINITY,
+            rlim_max: libc::RLIM_INFINITY,
+        };
+        let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+        if ret != 0 {
+            warn!("remove limit on locked memory failed, ret is: {}", ret);
+        }
+    }
+}
+
+#[cfg(feature = "ebpf")]
+pub use ebpf_source::RingBufSource;
+
+#[cfg(not(feature = "ebpf"))]
+mod park_source {
+    use std::time::Duration;
+
+    use oom_watcher_common::OomKillEvent;
+
+    use crate::watch::OomEventSource;
+
+    /// A source that never yields, for builds without the `ebpf` feature: the binary still
+    /// starts (and serves metrics) but has no probe to read.
+    pub struct ParkSource;
+
+    impl OomEventSource for ParkSource {
+        async fn next(&mut self) -> Option<OomKillEvent> {
+            loop {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "ebpf"))]
+pub use park_source::ParkSource;

--- a/oom-watcher/src/watch.rs
+++ b/oom-watcher/src/watch.rs
@@ -1,0 +1,269 @@
+//! The watch loop: the per-event pipeline that turns OOM kill events into recorded,
+//! enriched OOM events. See CONTEXT.md ("Watch loop").
+//!
+//! [`run`] owns the whole loop, pulling from an [`OomEventSource`], resolving through a
+//! [`ContainerResolver`], and reporting to a [`MetricsRecorder`]. It is generic over all
+//! three seams plus an injected clock, so the entire pipeline is the test surface: a
+//! finite source drives it to completion with no kernel and no Kubernetes.
+
+use log::{info, warn};
+use oom_watcher_common::{EnrichedOomEvent, OomKillEvent};
+
+use crate::{
+    enrich::enrich,
+    metrics::MetricsRecorder,
+    resolve::{ContainerResolver, ResolutionOutcome},
+};
+
+/// The seam for where OOM kill events reach userspace. `next` yields whole, decoded
+/// events; `None` means the stream has ended. A real source never ends, so in production
+/// the loop runs until the task is aborted; a finite test source ends and the loop returns.
+// Static dispatch only — the loop is generic over a concrete source, never `dyn`.
+#[allow(async_fn_in_trait)]
+pub trait OomEventSource {
+    async fn next(&mut self) -> Option<OomKillEvent>;
+}
+
+/// Run the watch loop: drain `source`, processing each OOM kill event, until it ends.
+pub async fn run<S, R, C>(
+    mut source: S,
+    resolver: Option<impl ContainerResolver>,
+    recorder: &R,
+    now: C,
+) where
+    S: OomEventSource,
+    R: MetricsRecorder,
+    C: Fn() -> u64,
+{
+    while let Some(raw_event) = source.next().await {
+        process_event(&raw_event, resolver.as_ref(), recorder, now()).await;
+    }
+}
+
+/// Process a single OOM kill event: run resolution (recording the outcome), collapse to an
+/// identity, enrich, then record the enriched event. The node name is known iff a resolver
+/// exists — the single source of the enrichment iff-rule.
+async fn process_event<R: MetricsRecorder>(
+    raw_event: &OomKillEvent,
+    resolver: Option<&impl ContainerResolver>,
+    recorder: &R,
+    timestamp: u64,
+) {
+    let (node_name, identity) = match resolver {
+        Some(client) => {
+            let outcome = client.resolve(raw_event.pid).await;
+            recorder.record_resolution_outcome(client.node_name(), &outcome);
+            match &outcome {
+                ResolutionOutcome::NotFound => {
+                    warn!("Could not find Kubernetes info for PID {}", raw_event.pid)
+                }
+                ResolutionOutcome::Failed(e) => warn!(
+                    "Error getting Kubernetes info for PID {}: {}",
+                    raw_event.pid, e
+                ),
+                ResolutionOutcome::Found(_) => {}
+            }
+            (Some(client.node_name().to_string()), outcome.identity())
+        }
+        None => (None, None),
+    };
+
+    let enriched = enrich(*raw_event, node_name.as_deref(), identity, timestamp);
+    recorder.record_oom_event(&enriched);
+    log_event(raw_event, &enriched);
+}
+
+fn log_event(raw_event: &OomKillEvent, enriched: &EnrichedOomEvent) {
+    let comm_str = std::str::from_utf8(&raw_event.comm)
+        .unwrap_or("?")
+        .trim_end_matches('\0');
+
+    info!("🚨 OOM EVENT DETECTED:");
+    info!("   Process: {} (PID: {})", comm_str, raw_event.pid);
+    if let Some(ref ns) = enriched.namespace {
+        info!(
+            "   Kubernetes: {}/{}/{}",
+            ns,
+            enriched.pod_name.as_deref().unwrap_or("unknown"),
+            enriched.container_name.as_deref().unwrap_or("unknown")
+        );
+    }
+    info!(
+        "   Memory: total-vm={}kB anon-rss={}kB file-rss={}kB shmem-rss={}kB",
+        raw_event.total_vm, raw_event.anon_rss, raw_event.file_rss, raw_event.shmem_rss
+    );
+    info!(
+        "   User: UID={} pgtables={}kB oom_score_adj={}",
+        raw_event.uid, raw_event.pgtables, raw_event.oom_score_adj
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::VecDeque};
+
+    use oom_watcher_common::ContainerIdentity;
+
+    use super::*;
+    use crate::resolve::{Behavior, FakeResolver};
+
+    /// In-memory event source — the second adapter for [`OomEventSource`], so the seam is
+    /// real and the loop is drivable in tests.
+    struct VecSource(VecDeque<OomKillEvent>);
+
+    impl OomEventSource for VecSource {
+        async fn next(&mut self) -> Option<OomKillEvent> {
+            self.0.pop_front()
+        }
+    }
+
+    fn source(events: impl IntoIterator<Item = OomKillEvent>) -> VecSource {
+        VecSource(events.into_iter().collect())
+    }
+
+    /// Recording spy — the second adapter for [`MetricsRecorder`]. Captures every call so
+    /// tests assert what the loop reported, with no Prometheus involved.
+    #[derive(Default)]
+    struct SpyRecorder {
+        outcomes: RefCell<Vec<(String, &'static str)>>,
+        events: RefCell<Vec<EnrichedOomEvent>>,
+    }
+
+    impl MetricsRecorder for SpyRecorder {
+        fn record_resolution_outcome(&self, node: &str, outcome: &ResolutionOutcome) {
+            let reason = match outcome {
+                ResolutionOutcome::Found(_) => "found",
+                ResolutionOutcome::NotFound => "not_found",
+                ResolutionOutcome::Failed(_) => "error",
+            };
+            self.outcomes.borrow_mut().push((node.to_string(), reason));
+        }
+
+        fn record_oom_event(&self, event: &EnrichedOomEvent) {
+            self.events.borrow_mut().push(event.clone());
+        }
+    }
+
+    fn raw(pid: u32) -> OomKillEvent {
+        OomKillEvent {
+            pid,
+            tgid: pid,
+            comm: *b"target\0\0\0\0\0\0\0\0\0\0",
+            total_vm: 100,
+            anon_rss: 50,
+            file_rss: 10,
+            shmem_rss: 5,
+            uid: 1000,
+            pgtables: 2,
+            oom_score_adj: 0,
+        }
+    }
+
+    fn identity() -> ContainerIdentity {
+        ContainerIdentity {
+            namespace: "prod".into(),
+            pod_name: "api-7d9".into(),
+            container_name: "api".into(),
+            container_id: "abc123".into(),
+        }
+    }
+
+    const CLOCK: u64 = 1_717_000_000;
+    fn clock() -> u64 {
+        CLOCK
+    }
+
+    #[tokio::test]
+    async fn enriches_and_records_a_resolved_event() {
+        let spy = SpyRecorder::default();
+        let resolver = Some(FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::Found(identity()),
+        });
+
+        run(source([raw(1234)]), resolver, &spy, clock).await;
+
+        let events = spy.events.borrow();
+        assert_eq!(events.len(), 1);
+        let e = &events[0];
+        assert_eq!(e.node_name.as_deref(), Some("node-1"));
+        assert_eq!(e.namespace.as_deref(), Some("prod"));
+        assert_eq!(e.pod_name.as_deref(), Some("api-7d9"));
+        assert_eq!(e.container_name.as_deref(), Some("api"));
+        assert_eq!(e.raw_event.pid, 1234);
+        assert_eq!(e.timestamp, CLOCK);
+        // The loop forwards every outcome; the adapter decides to ignore Found.
+        assert_eq!(
+            *spy.outcomes.borrow(),
+            vec![("node-1".to_string(), "found")]
+        );
+    }
+
+    #[tokio::test]
+    async fn keeps_node_but_no_identity_when_not_found() {
+        let spy = SpyRecorder::default();
+        let resolver = Some(FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::NotFound,
+        });
+
+        run(source([raw(1)]), resolver, &spy, clock).await;
+
+        let events = spy.events.borrow();
+        assert_eq!(events[0].node_name.as_deref(), Some("node-1"));
+        assert_eq!(events[0].namespace, None);
+        assert_eq!(events[0].container_id, None);
+        assert_eq!(
+            *spy.outcomes.borrow(),
+            vec![("node-1".to_string(), "not_found")]
+        );
+    }
+
+    #[tokio::test]
+    async fn records_failure_outcome_and_keeps_node() {
+        let spy = SpyRecorder::default();
+        let resolver = Some(FakeResolver {
+            node: "node-1".into(),
+            behavior: Behavior::Fail,
+        });
+
+        run(source([raw(1)]), resolver, &spy, clock).await;
+
+        assert_eq!(spy.events.borrow()[0].node_name.as_deref(), Some("node-1"));
+        assert_eq!(spy.events.borrow()[0].namespace, None);
+        assert_eq!(
+            *spy.outcomes.borrow(),
+            vec![("node-1".to_string(), "error")]
+        );
+    }
+
+    #[tokio::test]
+    async fn standalone_mode_has_no_node_and_records_no_outcome() {
+        let spy = SpyRecorder::default();
+        let resolver: Option<FakeResolver> = None;
+
+        run(source([raw(1)]), resolver, &spy, clock).await;
+
+        assert_eq!(spy.events.borrow()[0].node_name, None);
+        assert!(spy.outcomes.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn drains_every_event_in_order() {
+        let spy = SpyRecorder::default();
+        let resolver = Some(FakeResolver {
+            node: "n".into(),
+            behavior: Behavior::NotFound,
+        });
+
+        run(source([raw(1), raw(2), raw(3)]), resolver, &spy, clock).await;
+
+        let pids: Vec<u32> = spy
+            .events
+            .borrow()
+            .iter()
+            .map(|e| e.raw_event.pid)
+            .collect();
+        assert_eq!(pids, vec![1, 2, 3]);
+    }
+}


### PR DESCRIPTION
## What

Extracts the OOM-event pipeline out of `main`'s anonymous closure into a **watch loop** module, sitting behind two new seams so the whole pipeline becomes testable without a kernel or a live Kubernetes API.

### Seams (each with a real prod + test adapter)

| Seam | Module | Prod adapter | Test adapter |
|---|---|---|---|
| `OomEventSource` | `watch.rs` | `RingBufSource` (`source.rs`) | `VecSource` |
| `MetricsRecorder` | `metrics.rs` | `MetricsCollector` | `SpyRecorder` |

- **`watch.rs`** — `run(source, resolver, recorder, now)` owns the loop, generic over both seams + `ContainerResolver` + an injected clock. `main.rs` collapses to wiring with zero `aya` references.
- **`source.rs`** — `RingBufSource` owns the entire eBPF lifecycle and the single `unsafe` ring-buffer decode; `ParkSource` covers non-eBPF builds.
- **`metrics.rs` / `http.rs`** — the loop depends on the `MetricsRecorder` trait, not Prometheus. `MetricsCollector` keeps recording only; HTTP serving moves to `http.rs`, so axum no longer leaks through its interface (and the dead `_port` param is gone).

### Why the dependency changes

`aya`/`aya-log`/`libc` are now **optional, gated on the `ebpf` feature** (all usage is confined to `source.rs`), and the **dead `aya` dependency is dropped from `oom-watcher-common`**. The testable core now builds and tests on any platform, not just Linux.

## Verification

- Core (`--no-default-features`, macOS): 12 tests pass (5 new watch-loop tests), clippy clean.
- Production path (`--features ebpf`, real aya, Linux): `cargo check` and `cargo clippy --all-targets -D warnings` both pass.

Domain terms added to `CONTEXT.md`: **Watch loop**, **OOM event source**, **Metrics recorder**.